### PR TITLE
Make linting more strict

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -79,10 +79,12 @@
           #
           {Credo.Check.Consistency.ExceptionNames, []},
           {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
           {Credo.Check.Consistency.ParameterPatternMatching, []},
           {Credo.Check.Consistency.SpaceAroundOperators, []},
           {Credo.Check.Consistency.SpaceInParentheses, []},
           {Credo.Check.Consistency.TabsOrSpaces, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
 
           #
           ## Design Checks
@@ -92,6 +94,7 @@
           #
           {Credo.Check.Design.AliasUsage,
            [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
           # You can also customize the exit_status of each check.
           # If you don't want TODO comments to cause `mix credo` to fail, just
           # set this value to 0 (zero).
@@ -104,11 +107,22 @@
           #
           {Credo.Check.Readability.AliasOrder, []},
           {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.ImplTrue,
+           [
+             files: %{
+               excluded: [
+                 ~r"/lib/terrible/application.ex"
+               ]
+             }
+           ]},
           {Credo.Check.Readability.LargeNumbers, []},
           {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
           {Credo.Check.Readability.ModuleAttributeNames, []},
           {Credo.Check.Readability.ModuleDoc, []},
           {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
           {Credo.Check.Readability.ParenthesesInCondition, []},
           {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
           {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
@@ -116,19 +130,25 @@
           {Credo.Check.Readability.PreferImplicitTry, []},
           {Credo.Check.Readability.RedundantBlankLines, []},
           {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SinglePipe, []},
           {Credo.Check.Readability.SpaceAfterCommas, []},
           {Credo.Check.Readability.Specs,
-           files: %{
-             excluded: [
-               ~r"/lib/terrible_web/controllers/",
-               ~r"/lib/terrible_web/live/"
-             ]
-           }},
+           [
+             files: %{
+               excluded: [
+                 ~r"/lib/terrible_web/controllers/",
+                 ~r"/lib/terrible_web/live/"
+               ]
+             }
+           ]},
+          {Credo.Check.Readability.StrictModuleLayout, []},
           {Credo.Check.Readability.StringSigils, []},
           {Credo.Check.Readability.TrailingBlankLine, []},
           {Credo.Check.Readability.TrailingWhiteSpace, []},
           {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
           {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
           {Credo.Check.Readability.WithSingleClause, []},
 
           #
@@ -137,17 +157,23 @@
           {Credo.Check.Refactor.Apply, []},
           {Credo.Check.Refactor.CondStatements, []},
           {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
           {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.IoPuts, []},
           {Credo.Check.Refactor.LongQuoteBlocks, []},
           {Credo.Check.Refactor.MatchInCondition, []},
           {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.MapMap, []},
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},
           {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
           {Credo.Check.Refactor.Nesting, []},
           {Credo.Check.Refactor.UnlessWithElse, []},
           {Credo.Check.Refactor.WithClauses, []},
           {Credo.Check.Refactor.FilterCount, []},
           {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
           {Credo.Check.Refactor.RejectReject, []},
           {Credo.Check.Refactor.RedundantWithClauseResult, []},
 
@@ -160,7 +186,9 @@
           {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
           {Credo.Check.Warning.IExPry, []},
           {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
           {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.MixEnv, []},
           {Credo.Check.Warning.OperationOnSameValues, []},
           {Credo.Check.Warning.OperationWithConstantResult, []},
           {Credo.Check.Warning.RaiseInsideRescue, []},
@@ -174,6 +202,7 @@
           {Credo.Check.Warning.UnusedRegexOperation, []},
           {Credo.Check.Warning.UnusedStringOperation, []},
           {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.UnsafeToAtom, []},
           {Credo.Check.Warning.UnsafeExec, []}
         ],
         disabled: [
@@ -184,39 +213,19 @@
           # Controversial and experimental checks (opt-in, just move the check to `:enabled`
           #   and be sure to use `mix credo --strict` to see low priority checks)
           #
-          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
-          {Credo.Check.Consistency.UnusedVariableNames, []},
           {Credo.Check.Design.DuplicatedCode, []},
-          {Credo.Check.Design.SkipTestWithoutComment, []},
           {Credo.Check.Readability.AliasAs, []},
           {Credo.Check.Readability.BlockPipe, []},
-          {Credo.Check.Readability.ImplTrue, []},
-          {Credo.Check.Readability.MultiAlias, []},
-          {Credo.Check.Readability.NestedFunctionCalls, []},
-          {Credo.Check.Readability.OneArityFunctionInPipe, []},
-          {Credo.Check.Readability.SeparateAliasRequire, []},
           {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
-          {Credo.Check.Readability.SinglePipe, []},
-          {Credo.Check.Readability.StrictModuleLayout, []},
-          {Credo.Check.Readability.WithCustomTaggedTuple, []},
           {Credo.Check.Readability.OnePipePerLine, []},
           {Credo.Check.Refactor.ABCSize, []},
           {Credo.Check.Refactor.AppendSingleItem, []},
-          {Credo.Check.Refactor.DoubleBooleanNegation, []},
           {Credo.Check.Refactor.FilterReject, []},
-          {Credo.Check.Refactor.IoPuts, []},
-          {Credo.Check.Refactor.MapMap, []},
           {Credo.Check.Refactor.ModuleDependencies, []},
-          {Credo.Check.Refactor.NegatedIsNil, []},
-          {Credo.Check.Refactor.PassAsyncInTestCases, []},
-          {Credo.Check.Refactor.PipeChainStart, []},
           {Credo.Check.Refactor.RejectFilter, []},
           {Credo.Check.Refactor.VariableRebinding, []},
           {Credo.Check.Warning.LazyLogging, []},
-          {Credo.Check.Warning.LeakyEnvironment, []},
-          {Credo.Check.Warning.MapGetUnsafePass, []},
-          {Credo.Check.Warning.MixEnv, []},
-          {Credo.Check.Warning.UnsafeToAtom, []}
+          {Credo.Check.Warning.LeakyEnvironment, []}
 
           # {Credo.Check.Refactor.MapInto, []},
 

--- a/lib/terrible/identity/user.ex
+++ b/lib/terrible/identity/user.ex
@@ -142,6 +142,7 @@ defmodule Terrible.Identity.User do
   """
   @spec confirm_changeset(Ecto.Schema.t()) :: Ecto.Schema.t()
   def confirm_changeset(user) do
+    # credo:disable-for-next-line Credo.Check.Readability.SinglePipe
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
     change(user, confirmed_at: now)
   end
@@ -158,7 +159,7 @@ defmodule Terrible.Identity.User do
     Bcrypt.verify_pass(password, hashed_password)
   end
 
-  def valid_password?(_, _) do
+  def valid_password?(_any, _thing) do
     Bcrypt.no_user_verify()
     false
   end

--- a/lib/terrible/identity/user_token.ex
+++ b/lib/terrible/identity/user_token.ex
@@ -18,10 +18,10 @@ defmodule Terrible.Identity.UserToken do
   @type t :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
           id: integer() | nil,
-          token: binary(),
-          context: String.t(),
-          sent_to: String.t(),
-          user_id: integer(),
+          token: binary() | nil,
+          context: String.t() | nil,
+          sent_to: String.t() | nil,
+          user_id: integer() | nil,
           inserted_at: NaiveDateTime.t() | nil
         }
 
@@ -53,7 +53,7 @@ defmodule Terrible.Identity.UserToken do
   and devices in the UI and allow users to explicitly expire any
   session they deem invalid.
   """
-  # credo:disable-for-next-line Credo.Check.Readability.Specs
+  @spec build_session_token(Terrible.Identity.User.t()) :: {binary(), UserToken.t()}
   def build_session_token(user) do
     token = :crypto.strong_rand_bytes(@rand_size)
     {token, %UserToken{token: token, context: "session", user_id: user.id}}
@@ -160,7 +160,7 @@ defmodule Terrible.Identity.UserToken do
   The context must always start with "change:".
   """
   @spec verify_change_email_token_query(binary(), String.t()) :: {:ok, Ecto.Query.t()} | :error
-  def verify_change_email_token_query(token, "change:" <> _ = context) do
+  def verify_change_email_token_query(token, "change:" <> _type = context) do
     case Base.url_decode64(token, padding: false) do
       {:ok, decoded_token} ->
         hashed_token = :crypto.hash(@hash_algorithm, decoded_token)

--- a/lib/terrible_web/live/user_confirmation_live.ex
+++ b/lib/terrible_web/live/user_confirmation_live.ex
@@ -45,6 +45,7 @@ defmodule TerribleWeb.UserConfirmationLive do
         # by some automation or by the user themselves, so we redirect without
         # a warning message.
         case socket.assigns do
+          # credo:disable-for-next-line Credo.Check.Refactor.NegatedIsNil
           %{current_user: %{confirmed_at: confirmed_at}} when not is_nil(confirmed_at) ->
             {:noreply, redirect(socket, to: ~p"/")}
 

--- a/lib/terrible_web/live/user_reset_password_live.ex
+++ b/lib/terrible_web/live/user_reset_password_live.ex
@@ -47,7 +47,7 @@ defmodule TerribleWeb.UserResetPasswordLive do
         %{user: user} ->
           Identity.change_user_password(user)
 
-        _ ->
+        _any ->
           %{}
       end
 

--- a/lib/terrible_web/user_auth.ex
+++ b/lib/terrible_web/user_auth.ex
@@ -224,6 +224,7 @@ defmodule TerribleWeb.UserAuth do
   defp put_token_in_session(conn, token) do
     conn
     |> put_session(:user_token, token)
+    # credo:disable-for-next-line Credo.Check.Readability.NestedFunctionCalls
     |> put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
   end
 

--- a/test/terrible_web/controllers/page_controller_test.exs
+++ b/test/terrible_web/controllers/page_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TerribleWeb.PageControllerTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
   test "GET /", %{conn: conn} do
     conn = get(conn, ~p"/")

--- a/test/terrible_web/controllers/user_session_controller_test.exs
+++ b/test/terrible_web/controllers/user_session_controller_test.exs
@@ -56,8 +56,7 @@ defmodule TerribleWeb.UserSessionControllerTest do
 
     test "login following registration", %{conn: conn, user: user} do
       conn =
-        conn
-        |> post(~p"/users/log_in", %{
+        post(conn, ~p"/users/log_in", %{
           "_action" => "registered",
           "user" => %{
             "email" => user.email,
@@ -71,8 +70,7 @@ defmodule TerribleWeb.UserSessionControllerTest do
 
     test "login following password update", %{conn: conn, user: user} do
       conn =
-        conn
-        |> post(~p"/users/log_in", %{
+        post(conn, ~p"/users/log_in", %{
           "_action" => "password_updated",
           "user" => %{
             "email" => user.email,

--- a/test/terrible_web/live/user_confirmation_instructions_live_test.exs
+++ b/test/terrible_web/live/user_confirmation_instructions_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TerribleWeb.UserConfirmationInstructionsLiveTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Terrible.IdentityFixtures
@@ -33,7 +33,9 @@ defmodule TerribleWeb.UserConfirmationInstructionsLiveTest do
     end
 
     test "does not send confirmation token if user is confirmed", %{conn: conn, user: user} do
-      Repo.update!(Identity.User.confirm_changeset(user))
+      user
+      |> Identity.User.confirm_changeset()
+      |> Repo.update!()
 
       {:ok, lv, _html} = live(conn, ~p"/users/confirm")
 

--- a/test/terrible_web/live/user_confirmation_live_test.exs
+++ b/test/terrible_web/live/user_confirmation_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TerribleWeb.UserConfirmationLiveTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Terrible.IdentityFixtures

--- a/test/terrible_web/live/user_forgot_password_live_test.exs
+++ b/test/terrible_web/live/user_forgot_password_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TerribleWeb.UserForgotPasswordLiveTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Terrible.IdentityFixtures

--- a/test/terrible_web/live/user_login_live_test.exs
+++ b/test/terrible_web/live/user_login_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TerribleWeb.UserLoginLiveTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Terrible.IdentityFixtures

--- a/test/terrible_web/live/user_registration_live_test.exs
+++ b/test/terrible_web/live/user_registration_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TerribleWeb.UserRegistrationLiveTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Terrible.IdentityFixtures

--- a/test/terrible_web/live/user_reset_password_live_test.exs
+++ b/test/terrible_web/live/user_reset_password_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TerribleWeb.UserResetPasswordLiveTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Terrible.IdentityFixtures

--- a/test/terrible_web/live/user_settings_live_test.exs
+++ b/test/terrible_web/live/user_settings_live_test.exs
@@ -1,9 +1,10 @@
 defmodule TerribleWeb.UserSettingsLiveTest do
-  use TerribleWeb.ConnCase
+  use TerribleWeb.ConnCase, async: true
 
-  alias Terrible.Identity
   import Phoenix.LiveViewTest
   import Terrible.IdentityFixtures
+
+  alias Terrible.Identity
 
   describe "Settings page" do
     test "renders settings page", %{conn: conn} do


### PR DESCRIPTION
This enables a couple of Credo rules to ensure that code quality is great.

This also adds the missing typespec that was skipped from the previous commit.