### PR TITLE
Reduce Password length minimum requirement to 8

### DIFF
--- a/lib/terrible/identity/user.ex
+++ b/lib/terrible/identity/user.ex
@@ -66,7 +66,7 @@ defmodule Terrible.Identity.User do
   defp validate_password(changeset, opts) do
     changeset
     |> validate_required([:password])
-    |> validate_length(:password, min: 12, max: 72)
+    |> validate_length(:password, min: 8, max: 72)
     # Examples of additional password validation:
     # |> validate_format(:password, ~r/[a-z]/, message: "at least one lower case character")
     # |> validate_format(:password, ~r/[A-Z]/, message: "at least one upper case character")

--- a/test/terrible/identity_test.exs
+++ b/test/terrible/identity_test.exs
@@ -60,11 +60,11 @@ defmodule Terrible.IdentityTest do
     end
 
     test "validates email and password when given" do
-      {:error, changeset} = Identity.register_user(%{email: "not valid", password: "not valid"})
+      {:error, changeset} = Identity.register_user(%{email: "not valid", password: "short"})
 
       assert %{
                email: ["must have the @ sign and no spaces"],
-               password: ["should be at least 12 character(s)"]
+               password: ["should be at least 8 character(s)"]
              } = errors_on(changeset)
     end
 
@@ -268,12 +268,12 @@ defmodule Terrible.IdentityTest do
     test "validates password", %{user: user} do
       {:error, changeset} =
         Identity.update_user_password(user, valid_user_password(), %{
-          password: "not valid",
+          password: "short",
           password_confirmation: "another"
         })
 
       assert %{
-               password: ["should be at least 12 character(s)"],
+               password: ["should be at least 8 character(s)"],
                password_confirmation: ["does not match password"]
              } = errors_on(changeset)
     end
@@ -477,12 +477,12 @@ defmodule Terrible.IdentityTest do
     test "validates password", %{user: user} do
       {:error, changeset} =
         Identity.reset_user_password(user, %{
-          password: "not valid",
+          password: "short",
           password_confirmation: "another"
         })
 
       assert %{
-               password: ["should be at least 12 character(s)"],
+               password: ["should be at least 8 character(s)"],
                password_confirmation: ["does not match password"]
              } = errors_on(changeset)
     end

--- a/test/terrible_web/live/user_registration_live_test.exs
+++ b/test/terrible_web/live/user_registration_live_test.exs
@@ -28,11 +28,11 @@ defmodule TerribleWeb.UserRegistrationLiveTest do
       result =
         lv
         |> element("#registration_form")
-        |> render_change(user: %{"email" => "with spaces", "password" => "too short"})
+        |> render_change(user: %{"email" => "with spaces", "password" => "short"})
 
       assert result =~ "Register"
       assert result =~ "must have the @ sign and no spaces"
-      assert result =~ "should be at least 12 character"
+      assert result =~ "should be at least 8 character"
     end
   end
 

--- a/test/terrible_web/live/user_reset_password_live_test.exs
+++ b/test/terrible_web/live/user_reset_password_live_test.exs
@@ -40,10 +40,10 @@ defmodule TerribleWeb.UserResetPasswordLiveTest do
         lv
         |> element("#reset_password_form")
         |> render_change(
-          user: %{"password" => "secret12", "confirmation_password" => "secret123456"}
+          user: %{"password" => "shorty", "confirmation_password" => "secret123456"}
         )
 
-      assert result =~ "should be at least 12 character"
+      assert result =~ "should be at least 8 character"
       assert result =~ "does not match password"
     end
   end
@@ -75,14 +75,14 @@ defmodule TerribleWeb.UserResetPasswordLiveTest do
         lv
         |> form("#reset_password_form",
           user: %{
-            "password" => "too short",
+            "password" => "short",
             "password_confirmation" => "does not match"
           }
         )
         |> render_submit()
 
       assert result =~ "Reset Password"
-      assert result =~ "should be at least 12 character(s)"
+      assert result =~ "should be at least 8 character(s)"
       assert result =~ "does not match password"
     end
   end

--- a/test/terrible_web/live/user_settings_live_test.exs
+++ b/test/terrible_web/live/user_settings_live_test.exs
@@ -128,13 +128,13 @@ defmodule TerribleWeb.UserSettingsLiveTest do
         |> render_change(%{
           "current_password" => "invalid",
           "user" => %{
-            "password" => "too short",
+            "password" => "short",
             "password_confirmation" => "does not match"
           }
         })
 
       assert result =~ "Change Password"
-      assert result =~ "should be at least 12 character(s)"
+      assert result =~ "should be at least 8 character(s)"
       assert result =~ "does not match password"
     end
 
@@ -146,14 +146,14 @@ defmodule TerribleWeb.UserSettingsLiveTest do
         |> form("#password_form", %{
           "current_password" => "invalid",
           "user" => %{
-            "password" => "too short",
+            "password" => "short",
             "password_confirmation" => "does not match"
           }
         })
         |> render_submit()
 
       assert result =~ "Change Password"
-      assert result =~ "should be at least 12 character(s)"
+      assert result =~ "should be at least 8 character(s)"
       assert result =~ "does not match password"
       assert result =~ "is not valid"
     end


### PR DESCRIPTION
My hot take on this is that forcing users to go completely out of their comfort zone when choosing a password is counterproductive to password security.